### PR TITLE
Assigning an autorezizing mask for correctly sizing for smaller devices

### DIFF
--- a/SwiftyOnboard/SwiftyOnboard.swift
+++ b/SwiftyOnboard/SwiftyOnboard.swift
@@ -87,6 +87,7 @@ public class SwiftyOnboard: UIView, UIScrollViewDelegate {
     
     public init(frame: CGRect, style: SwiftyOnboardStyle = .dark) {
         super.init(frame: frame)
+        self.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.style = style
     }
     


### PR DESCRIPTION
Noticed when running on an iPod Touch the sizing was incorrect. I could do the same using autolayout but decided for this because it was cleaner.