### PR TITLE
Updated overlay layout constraints to use layoutMarginsGuide.

### DIFF
--- a/SwiftyOnboard/SwiftyOnboardOverlay.swift
+++ b/SwiftyOnboard/SwiftyOnboardOverlay.swift
@@ -72,25 +72,27 @@ open class SwiftyOnboardOverlay: UIView {
     
     func setUp() {
         self.addSubview(pageControl)
+        
+        let margin = self.layoutMarginsGuide
         pageControl.translatesAutoresizingMaskIntoConstraints = false
         pageControl.heightAnchor.constraint(equalToConstant: 15).isActive = true
-        pageControl.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true
-        pageControl.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 10).isActive = true
-        pageControl.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -10).isActive = true
+        pageControl.bottomAnchor.constraint(equalTo: margin.bottomAnchor, constant: -10).isActive = true
+        pageControl.leftAnchor.constraint(equalTo: margin.leftAnchor, constant: 10).isActive = true
+        pageControl.rightAnchor.constraint(equalTo: margin.rightAnchor, constant: -10).isActive = true
         
         self.addSubview(continueButton)
         continueButton.translatesAutoresizingMaskIntoConstraints = false
         continueButton.heightAnchor.constraint(equalToConstant: 20).isActive = true
         continueButton.bottomAnchor.constraint(equalTo: pageControl.topAnchor, constant: -20).isActive = true
-        continueButton.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 10).isActive = true
-        continueButton.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -10).isActive = true
+        continueButton.leftAnchor.constraint(equalTo: margin.leftAnchor, constant: 10).isActive = true
+        continueButton.rightAnchor.constraint(equalTo: margin.rightAnchor, constant: -10).isActive = true
         
         self.addSubview(skipButton)
         skipButton.translatesAutoresizingMaskIntoConstraints = false
         skipButton.heightAnchor.constraint(equalToConstant: 20).isActive = true
-        skipButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 40).isActive = true
-        skipButton.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 10).isActive = true
-        skipButton.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -20).isActive = true
+        skipButton.topAnchor.constraint(equalTo: margin.topAnchor, constant: 10).isActive = true
+        skipButton.leftAnchor.constraint(equalTo: margin.leftAnchor, constant: 10).isActive = true
+        skipButton.rightAnchor.constraint(equalTo: margin.rightAnchor, constant: -20).isActive = true
     }
     
 }

--- a/SwiftyOnboard/SwiftyOnboardPage.swift
+++ b/SwiftyOnboard/SwiftyOnboardPage.swift
@@ -58,23 +58,25 @@ open class SwiftyOnboardPage: UIView {
     
     func setUp() {
         self.addSubview(imageView)
+        
+        let margin = self.layoutMarginsGuide
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 30).isActive = true
-        imageView.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -30).isActive = true
-        imageView.topAnchor.constraint(equalTo: self.topAnchor, constant: 10).isActive = true
-        imageView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.5).isActive = true
+        imageView.leftAnchor.constraint(equalTo: margin.leftAnchor, constant: 30).isActive = true
+        imageView.rightAnchor.constraint(equalTo: margin.rightAnchor, constant: -30).isActive = true
+        imageView.topAnchor.constraint(equalTo: margin.topAnchor, constant: 10).isActive = true
+        imageView.heightAnchor.constraint(equalTo: margin.heightAnchor, multiplier: 0.5).isActive = true
         
         self.addSubview(title)
         title.translatesAutoresizingMaskIntoConstraints = false
-        title.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 30).isActive = true
-        title.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -30).isActive = true
+        title.leftAnchor.constraint(equalTo: margin.leftAnchor, constant: 30).isActive = true
+        title.rightAnchor.constraint(equalTo: margin.rightAnchor, constant: -30).isActive = true
         title.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 10).isActive = true
         title.heightAnchor.constraint(equalToConstant: 50).isActive = true
         
         self.addSubview(subTitle)
         subTitle.translatesAutoresizingMaskIntoConstraints = false
-        subTitle.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 30).isActive = true
-        subTitle.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -30).isActive = true
+        subTitle.leftAnchor.constraint(equalTo: margin.leftAnchor, constant: 30).isActive = true
+        subTitle.rightAnchor.constraint(equalTo: margin.rightAnchor, constant: -30).isActive = true
         subTitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 0).isActive = true
         subTitle.heightAnchor.constraint(equalToConstant: 100).isActive = true
     }


### PR DESCRIPTION
By using `layoutMarginsGuide`, the `pageControl` does not overlap the swipe up bar on the iPhone X. I also tested the layout on the iPhone 5S and iPhone 7 simulators to ensure layout looked correct. I decreased the `topAnchor` constant for the `skipButton` from `40` to `10` since the `layoutMarginsGuide` already pushes it down from the top a bit.