### PR TITLE
Support changing shouldSwipe at any time (#22)

### DIFF
--- a/SwiftyOnboard/SwiftyOnboard.swift
+++ b/SwiftyOnboard/SwiftyOnboard.swift
@@ -81,7 +81,11 @@ public class SwiftyOnboard: UIView, UIScrollViewDelegate {
     fileprivate var pages = [SwiftyOnboardPage]()
     
     open var style: SwiftyOnboardStyle = .dark
-    open var shouldSwipe: Bool = true
+    open var shouldSwipe: Bool = true {
+        didSet {
+            containerView.isScrollEnabled = shouldSwipe
+        }
+    }
     open var fadePages: Bool = true
     
     


### PR DESCRIPTION
I use the `didSet` method of `shouldSwipe` to be able to change the `isScrollEnabled` property of the container view.